### PR TITLE
HxCS

### DIFF
--- a/lib/content-services/src/lib/content-metadata/services/content-metadata.service.ts
+++ b/lib/content-services/src/lib/content-metadata/services/content-metadata.service.ts
@@ -26,10 +26,9 @@ import { ContentMetadataConfigFactory } from './config/content-metadata-config.f
 import { PropertyDescriptorsService } from './property-descriptors.service';
 import { map, switchMap } from 'rxjs/operators';
 import { ContentTypePropertiesService } from './content-type-property.service';
-@Injectable({
-    providedIn: 'root'
-})
-export class ContentMetadataService {
+
+@Injectable()
+export class ContentMetadataServiceImpl implements ContentMetadataService {
 
     error = new Subject<{ statusCode: number, message: string }>();
 
@@ -86,14 +85,26 @@ export class ContentMetadataService {
         return groupedProperties;
     }
 
-    setTitleToNameIfNotSet(propertyGroups: OrganisedPropertyGroup[]): OrganisedPropertyGroup[] {
+    private setTitleToNameIfNotSet(propertyGroups: OrganisedPropertyGroup[]): OrganisedPropertyGroup[] {
         propertyGroups.map((propertyGroup) => {
             propertyGroup.title = propertyGroup.title || propertyGroup.name;
         });
         return propertyGroups;
     }
 
-    filterEmptyPreset(propertyGroups: OrganisedPropertyGroup[]): OrganisedPropertyGroup[]  {
+    private filterEmptyPreset(propertyGroups: OrganisedPropertyGroup[]): OrganisedPropertyGroup[]  {
         return propertyGroups.filter((props) => props.properties.length);
     }
+}
+
+@Injectable({
+    providedIn: 'root',
+    useClass: ContentMetadataServiceImpl
+})
+export abstract class ContentMetadataService {
+    error: Subject<{ statusCode: number, message: string }>;
+    abstract getBasicProperties(node: Node): Observable<CardViewItem[]>;
+    abstract getContentTypeProperty(node: Node): Observable<CardViewItem[]>;
+    abstract openConfirmDialog(changedProperties): Observable<any>;
+    abstract getGroupedProperties(node: Node, preset: string | PresetConfig): Observable<CardViewGroup[]>;
 }

--- a/lib/content-services/src/lib/content-metadata/services/property-descriptors.service.ts
+++ b/lib/content-services/src/lib/content-metadata/services/property-descriptors.service.ts
@@ -25,7 +25,12 @@ import { ClassesApi } from '@alfresco/js-api';
 @Injectable({
     providedIn: 'root'
 })
-export class PropertyDescriptorsService {
+export abstract class PropertyDescriptorsService {
+    abstract load(groupNames: string[]): Observable<PropertyGroupContainer>;
+}
+
+@Injectable()
+export class PropertyDescriptorsServiceImpl implements PropertyDescriptorsService {
 
     private _classesApi;
     get classesApi(): ClassesApi {

--- a/lib/content-services/src/lib/content-node-selector/content-node-selector-panel.component.ts
+++ b/lib/content-services/src/lib/content-node-selector/content-node-selector-panel.component.ts
@@ -65,7 +65,7 @@ export const defaultValidation = () => true;
     host: { 'class': 'adf-content-node-selector-panel' },
     providers: [{
         provide: SEARCH_QUERY_SERVICE_TOKEN,
-        useClass: SearchQueryBuilderService
+        useExisting: SearchQueryBuilderService
     }]
 })
 export class ContentNodeSelectorPanelComponent implements OnInit, OnDestroy {

--- a/lib/content-services/src/lib/content-node-selector/content-node-selector.module.ts
+++ b/lib/content-services/src/lib/content-node-selector/content-node-selector.module.ts
@@ -29,7 +29,6 @@ import { CoreModule } from '@alfresco/adf-core';
 import { DocumentListModule } from '../document-list/document-list.module';
 import { NameLocationCellComponent } from './name-location-cell/name-location-cell.component';
 import { UploadModule } from '../upload/upload.module';
-import { SearchQueryBuilderService } from '../search/services/search-query-builder.service';
 import { ContentDirectiveModule } from '../directives/content-directive.module';
 
 @NgModule({
@@ -55,7 +54,6 @@ import { ContentDirectiveModule } from '../directives/content-directive.module';
         ContentNodeSelectorPanelComponent,
         NameLocationCellComponent,
         ContentNodeSelectorComponent
-    ],
-    providers: [SearchQueryBuilderService]
+    ]
 })
 export class ContentNodeSelectorModule {}

--- a/lib/content-services/src/lib/document-list/components/filter-header/filter-header.component.spec.ts
+++ b/lib/content-services/src/lib/document-list/components/filter-header/filter-header.component.spec.ts
@@ -53,7 +53,7 @@ describe('FilterHeaderComponent', () => {
         ],
         providers: [
             { provide: SearchService, useValue: searchMock },
-            { provide: SEARCH_QUERY_SERVICE_TOKEN, useClass: SearchHeaderQueryBuilderService },
+            { provide: SEARCH_QUERY_SERVICE_TOKEN, useExisting: SearchHeaderQueryBuilderService },
             { provide: DocumentListComponent, useValue: documentListMock },
             DataTableComponent
         ]

--- a/lib/content-services/src/lib/document-list/components/filter-header/filter-header.component.ts
+++ b/lib/content-services/src/lib/document-list/components/filter-header/filter-header.component.ts
@@ -28,7 +28,7 @@ import { NodePaging, MinimalNode } from '@alfresco/js-api';
 @Component({
     selector: 'adf-filter-header',
     templateUrl: './filter-header.component.html',
-    providers: [{ provide: SEARCH_QUERY_SERVICE_TOKEN, useClass: SearchHeaderQueryBuilderService}]
+    providers: [{ provide: SEARCH_QUERY_SERVICE_TOKEN, useExisting: SearchHeaderQueryBuilderService}]
 })
 export class FilterHeaderComponent implements OnInit, OnChanges {
 

--- a/lib/content-services/src/lib/group/services/group.service.ts
+++ b/lib/content-services/src/lib/group/services/group.service.ts
@@ -36,6 +36,7 @@ export class GroupService {
     }
 
     async listAllGroupMembershipsForPerson(personId: string, opts?: any, accumulator = []): Promise<GroupEntry[]> {
+        return Promise.resolve([]);
         const groupsPaginated = await this.groupsApi.listGroupMembershipsForPerson(personId, opts);
         accumulator = [...accumulator, ...groupsPaginated.list.entries];
         if (groupsPaginated.list.pagination.hasMoreItems) {

--- a/lib/content-services/src/lib/search/components/search-form/search-form.component.spec.ts
+++ b/lib/content-services/src/lib/search/components/search-form/search-form.component.spec.ts
@@ -41,7 +41,7 @@ describe('SearchFormComponent', () => {
             ContentTestingModule
         ],
         providers: [
-            { provide: SEARCH_QUERY_SERVICE_TOKEN, useClass: SearchQueryBuilderService }
+            { provide: SEARCH_QUERY_SERVICE_TOKEN, useExisting: SearchQueryBuilderService }
         ]
     });
 

--- a/lib/content-services/src/lib/search/services/search-query-builder.service.spec.ts
+++ b/lib/content-services/src/lib/search/services/search-query-builder.service.spec.ts
@@ -15,7 +15,7 @@
  * limitations under the License.
  */
 
-import { SearchQueryBuilderService } from './search-query-builder.service';
+import { SearchQueryBuilderService, SearchQueryBuilderServiceImpl } from './search-query-builder.service';
 import { SearchConfiguration } from '../models/search-configuration.interface';
 import { AlfrescoApiService, AppConfigService } from '@alfresco/adf-core';
 import { FacetField } from '../models/facet-field.interface';
@@ -48,7 +48,7 @@ describe('SearchQueryBuilder', () => {
             ]
         };
         const alfrescoApiService = TestBed.inject(AlfrescoApiService);
-        const builder = new SearchQueryBuilderService(buildConfig(config), alfrescoApiService);
+        const builder = new SearchQueryBuilderServiceImpl(buildConfig(config), alfrescoApiService);
 
         builder.categories = [];
         builder.filterQueries = [];
@@ -64,14 +64,14 @@ describe('SearchQueryBuilder', () => {
 
     it('should have empty user query by default', () => {
         const alfrescoApiService = TestBed.inject(AlfrescoApiService);
-        const builder = new SearchQueryBuilderService(buildConfig({}), alfrescoApiService);
+        const builder = new SearchQueryBuilderServiceImpl(buildConfig({}), alfrescoApiService);
         expect(builder.userQuery).toBe('');
     });
 
     it('should wrap user query with brackets', () => {
         const alfrescoApiService = TestBed.inject(AlfrescoApiService);
 
-        const builder = new SearchQueryBuilderService(buildConfig({}), alfrescoApiService);
+        const builder = new SearchQueryBuilderServiceImpl(buildConfig({}), alfrescoApiService);
         builder.userQuery = 'my query';
         expect(builder.userQuery).toEqual('(my query)');
     });
@@ -79,7 +79,7 @@ describe('SearchQueryBuilder', () => {
     it('should trim user query value', () => {
         const alfrescoApiService = TestBed.inject(AlfrescoApiService);
 
-        const builder = new SearchQueryBuilderService(buildConfig({}), alfrescoApiService);
+        const builder = new SearchQueryBuilderServiceImpl(buildConfig({}), alfrescoApiService);
         builder.userQuery = ' something   ';
         expect(builder.userQuery).toEqual('(something)');
     });
@@ -94,7 +94,7 @@ describe('SearchQueryBuilder', () => {
         };
         const alfrescoApiService = TestBed.inject(AlfrescoApiService);
 
-        const builder = new SearchQueryBuilderService(buildConfig(config), alfrescoApiService);
+        const builder = new SearchQueryBuilderServiceImpl(buildConfig(config), alfrescoApiService);
 
         expect(builder.categories.length).toBe(2);
         expect(builder.categories[0].id).toBe('cat1');
@@ -110,7 +110,7 @@ describe('SearchQueryBuilder', () => {
             ]
         };
         const alfrescoApiService = TestBed.inject(AlfrescoApiService);
-        const builder = new SearchQueryBuilderService(buildConfig(config), alfrescoApiService);
+        const builder = new SearchQueryBuilderServiceImpl(buildConfig(config), alfrescoApiService);
 
         expect(builder.filterQueries.length).toBe(2);
         expect(builder.filterQueries[0].query).toBe('query1');
@@ -120,7 +120,7 @@ describe('SearchQueryBuilder', () => {
     it('should add new filter query', () => {
         const alfrescoApiService = TestBed.inject(AlfrescoApiService);
 
-        const builder = new SearchQueryBuilderService(buildConfig({}), alfrescoApiService);
+        const builder = new SearchQueryBuilderServiceImpl(buildConfig({}), alfrescoApiService);
 
         builder.addFilterQuery('q1');
 
@@ -131,7 +131,7 @@ describe('SearchQueryBuilder', () => {
     it('should not add empty filter query', () => {
         const alfrescoApiService = TestBed.inject(AlfrescoApiService);
 
-        const builder = new SearchQueryBuilderService(buildConfig({}), alfrescoApiService);
+        const builder = new SearchQueryBuilderServiceImpl(buildConfig({}), alfrescoApiService);
 
         builder.addFilterQuery(null);
         builder.addFilterQuery('');
@@ -142,7 +142,7 @@ describe('SearchQueryBuilder', () => {
     it('should not add duplicate filter query', () => {
         const alfrescoApiService = TestBed.inject(AlfrescoApiService);
 
-        const builder = new SearchQueryBuilderService(buildConfig({}), alfrescoApiService);
+        const builder = new SearchQueryBuilderServiceImpl(buildConfig({}), alfrescoApiService);
 
         builder.addFilterQuery('q1');
         builder.addFilterQuery('q1');
@@ -155,7 +155,7 @@ describe('SearchQueryBuilder', () => {
     it('should remove filter query', () => {
         const alfrescoApiService = TestBed.inject(AlfrescoApiService);
 
-        const builder = new SearchQueryBuilderService(buildConfig({}), alfrescoApiService);
+        const builder = new SearchQueryBuilderServiceImpl(buildConfig({}), alfrescoApiService);
 
         builder.addFilterQuery('q1');
         builder.addFilterQuery('q2');
@@ -169,7 +169,7 @@ describe('SearchQueryBuilder', () => {
     it('should not remove empty query', () => {
         const alfrescoApiService = TestBed.inject(AlfrescoApiService);
 
-        const builder = new SearchQueryBuilderService(buildConfig({}), alfrescoApiService);
+        const builder = new SearchQueryBuilderServiceImpl(buildConfig({}), alfrescoApiService);
         builder.addFilterQuery('q1');
         builder.addFilterQuery('q2');
         expect(builder.filterQueries.length).toBe(2);
@@ -191,7 +191,7 @@ describe('SearchQueryBuilder', () => {
         };
         const alfrescoApiService = TestBed.inject(AlfrescoApiService);
 
-        const builder = new SearchQueryBuilderService(buildConfig(config), alfrescoApiService);
+        const builder = new SearchQueryBuilderServiceImpl(buildConfig(config), alfrescoApiService);
         const query = builder.getFacetQuery('query2');
 
         expect(query.query).toBe('q2');
@@ -209,7 +209,7 @@ describe('SearchQueryBuilder', () => {
         };
         const alfrescoApiService = TestBed.inject(AlfrescoApiService);
 
-        const builder = new SearchQueryBuilderService(buildConfig(config), alfrescoApiService);
+        const builder = new SearchQueryBuilderServiceImpl(buildConfig(config), alfrescoApiService);
 
         const query1 = builder.getFacetQuery('');
         expect(query1).toBeNull();
@@ -230,7 +230,7 @@ describe('SearchQueryBuilder', () => {
         };
         const alfrescoApiService = TestBed.inject(AlfrescoApiService);
 
-        const builder = new SearchQueryBuilderService(buildConfig(config), alfrescoApiService);
+        const builder = new SearchQueryBuilderServiceImpl(buildConfig(config), alfrescoApiService);
         const field = builder.getFacetField('Size');
 
         expect(field.label).toBe('Size');
@@ -249,7 +249,7 @@ describe('SearchQueryBuilder', () => {
         };
         const alfrescoApiService = TestBed.inject(AlfrescoApiService);
 
-        const builder = new SearchQueryBuilderService(buildConfig(config), alfrescoApiService);
+        const builder = new SearchQueryBuilderServiceImpl(buildConfig(config), alfrescoApiService);
         const field = builder.getFacetField('Missing');
 
         expect(field).toBeFalsy();
@@ -266,7 +266,7 @@ describe('SearchQueryBuilder', () => {
         };
         const alfrescoApiService = TestBed.inject(AlfrescoApiService);
 
-        const builder = new SearchQueryBuilderService(buildConfig(config), alfrescoApiService);
+        const builder = new SearchQueryBuilderServiceImpl(buildConfig(config), alfrescoApiService);
         const field = builder.getFacetField('Label with spaces');
 
         expect(field.label).toBe('"Label with spaces"');
@@ -281,7 +281,7 @@ describe('SearchQueryBuilder', () => {
         };
         const alfrescoApiService = TestBed.inject(AlfrescoApiService);
 
-        const builder = new SearchQueryBuilderService(buildConfig(config), alfrescoApiService);
+        const builder = new SearchQueryBuilderServiceImpl(buildConfig(config), alfrescoApiService);
         builder.queryFragments['cat1'] = null;
 
         const compiled = builder.buildQuery();
@@ -296,7 +296,7 @@ describe('SearchQueryBuilder', () => {
         };
         const alfrescoApiService = TestBed.inject(AlfrescoApiService);
 
-        const builder = new SearchQueryBuilderService(buildConfig(config), alfrescoApiService);
+        const builder = new SearchQueryBuilderServiceImpl(buildConfig(config), alfrescoApiService);
 
         builder.queryFragments['cat1'] = 'cm:name:test';
 
@@ -313,7 +313,7 @@ describe('SearchQueryBuilder', () => {
         };
         const alfrescoApiService = TestBed.inject(AlfrescoApiService);
 
-        const builder = new SearchQueryBuilderService(buildConfig(config), alfrescoApiService);
+        const builder = new SearchQueryBuilderServiceImpl(buildConfig(config), alfrescoApiService);
 
         builder.queryFragments['cat1'] = 'cm:name:test';
         builder.queryFragments['cat2'] = 'NOT cm:creator:System';
@@ -334,7 +334,7 @@ describe('SearchQueryBuilder', () => {
         };
         const alfrescoApiService = TestBed.inject(AlfrescoApiService);
 
-        const builder = new SearchQueryBuilderService(buildConfig(config), alfrescoApiService);
+        const builder = new SearchQueryBuilderServiceImpl(buildConfig(config), alfrescoApiService);
 
         builder.queryFragments['cat1'] = 'cm:name:test';
 
@@ -352,7 +352,7 @@ describe('SearchQueryBuilder', () => {
         };
         const alfrescoApiService = TestBed.inject(AlfrescoApiService);
 
-        const builder = new SearchQueryBuilderService(buildConfig(config), alfrescoApiService);
+        const builder = new SearchQueryBuilderServiceImpl(buildConfig(config), alfrescoApiService);
 
         builder.queryFragments['cat1'] = 'cm:name:test';
 
@@ -368,7 +368,7 @@ describe('SearchQueryBuilder', () => {
         };
         const alfrescoApiService = TestBed.inject(AlfrescoApiService);
 
-        const builder = new SearchQueryBuilderService(buildConfig(config), alfrescoApiService);
+        const builder = new SearchQueryBuilderServiceImpl(buildConfig(config), alfrescoApiService);
         builder.queryFragments['cat1'] = 'cm:name:test';
         builder.addFilterQuery('query1');
 
@@ -391,7 +391,7 @@ describe('SearchQueryBuilder', () => {
         };
         const alfrescoApiService = TestBed.inject(AlfrescoApiService);
 
-        const builder = new SearchQueryBuilderService(buildConfig(config), alfrescoApiService);
+        const builder = new SearchQueryBuilderServiceImpl(buildConfig(config), alfrescoApiService);
         builder.queryFragments['cat1'] = 'cm:name:test';
 
         const compiled = builder.buildQuery();
@@ -412,7 +412,7 @@ describe('SearchQueryBuilder', () => {
         };
         const alfrescoApiService = TestBed.inject(AlfrescoApiService);
 
-        const builder = new SearchQueryBuilderService(buildConfig(config), alfrescoApiService);
+        const builder = new SearchQueryBuilderServiceImpl(buildConfig(config), alfrescoApiService);
         builder.queryFragments['cat1'] = 'cm:name:test';
 
         const compiled = builder.buildQuery();
@@ -456,7 +456,7 @@ describe('SearchQueryBuilder', () => {
         };
         const alfrescoApiService = TestBed.inject(AlfrescoApiService);
 
-        const builder = new SearchQueryBuilderService(buildConfig(config), alfrescoApiService);
+        const builder = new SearchQueryBuilderServiceImpl(buildConfig(config), alfrescoApiService);
         builder.queryFragments['cat1'] = 'cm:name:test';
 
         const compiled = builder.buildQuery();
@@ -494,7 +494,7 @@ describe('SearchQueryBuilder', () => {
         };
         const alfrescoApiService = TestBed.inject(AlfrescoApiService);
 
-        const builder = new SearchQueryBuilderService(buildConfig(config), alfrescoApiService);
+        const builder = new SearchQueryBuilderServiceImpl(buildConfig(config), alfrescoApiService);
         builder.queryFragments['cat1'] = 'cm:name:test';
 
         const compiled = builder.buildQuery();
@@ -542,7 +542,7 @@ describe('SearchQueryBuilder', () => {
         };
         const alfrescoApiService = TestBed.inject(AlfrescoApiService);
 
-        const builder = new SearchQueryBuilderService(buildConfig(config), alfrescoApiService);
+        const builder = new SearchQueryBuilderServiceImpl(buildConfig(config), alfrescoApiService);
         builder.queryFragments['cat1'] = 'cm:name:test';
 
         const compiled = builder.buildQuery();
@@ -563,7 +563,7 @@ describe('SearchQueryBuilder', () => {
             ]
         };
         const alfrescoApiService = TestBed.inject(AlfrescoApiService);
-        const builder = new SearchQueryBuilderService(buildConfig(config), alfrescoApiService);
+        const builder = new SearchQueryBuilderServiceImpl(buildConfig(config), alfrescoApiService);
         const sorting: any = { type: 'FIELD', field: 'cm:name', ascending: true };
         builder.sorting = [sorting];
 
@@ -580,7 +580,7 @@ describe('SearchQueryBuilder', () => {
             ]
         };
         const alfrescoApiService = TestBed.inject(AlfrescoApiService);
-        const builder = new SearchQueryBuilderService(buildConfig(config), alfrescoApiService);
+        const builder = new SearchQueryBuilderServiceImpl(buildConfig(config), alfrescoApiService);
         builder.queryFragments['cat1'] = 'cm:name:test';
         builder.paging = { maxItems: 5, skipCount: 5 };
 
@@ -598,7 +598,7 @@ describe('SearchQueryBuilder', () => {
             ]
         };
         const alfrescoApiService = TestBed.inject(AlfrescoApiService);
-        const builder = new SearchQueryBuilderService(buildConfig(config), alfrescoApiService);
+        const builder = new SearchQueryBuilderServiceImpl(buildConfig(config), alfrescoApiService);
         builder.userQuery = 'my query';
 
         builder.queryFragments['cat1'] = 'cm:name:test';
@@ -635,7 +635,7 @@ describe('SearchQueryBuilder', () => {
         };
         const alfrescoApiService = TestBed.inject(AlfrescoApiService);
 
-        const builder = new SearchQueryBuilderService(buildConfig(config), alfrescoApiService);
+        const builder = new SearchQueryBuilderServiceImpl(buildConfig(config), alfrescoApiService);
 
         builder.addUserFacetBucket(field1, field1buckets[0]);
         builder.addUserFacetBucket(field1, field1buckets[1]);
@@ -658,7 +658,7 @@ describe('SearchQueryBuilder', () => {
         };
         const alfrescoApiService = TestBed.inject(AlfrescoApiService);
 
-        const builder = new SearchQueryBuilderService(buildConfig(config), alfrescoApiService);
+        const builder = new SearchQueryBuilderServiceImpl(buildConfig(config), alfrescoApiService);
         builder.userQuery = 'my query';
 
         builder.queryFragments['cat1'] = 'cm:name:test';
@@ -677,7 +677,7 @@ describe('SearchQueryBuilder', () => {
         };
         const alfrescoApiService = TestBed.inject(AlfrescoApiService);
 
-        const builder = new SearchQueryBuilderService(buildConfig(config), alfrescoApiService);
+        const builder = new SearchQueryBuilderServiceImpl(buildConfig(config), alfrescoApiService);
         spyOn(builder, 'buildQuery').and.throwError('some error');
 
         builder.error.subscribe(() => {
@@ -695,7 +695,7 @@ describe('SearchQueryBuilder', () => {
         };
         const alfrescoApiService = TestBed.inject(AlfrescoApiService);
 
-        const builder = new SearchQueryBuilderService(buildConfig(config), alfrescoApiService);
+        const builder = new SearchQueryBuilderServiceImpl(buildConfig(config), alfrescoApiService);
         spyOn(builder, 'buildQuery').and.throwError('some error');
 
         builder.executed.subscribe((data) => {
@@ -710,7 +710,7 @@ describe('SearchQueryBuilder', () => {
     it('should include contain the path and allowableOperations by default', () => {
         const alfrescoApiService = TestBed.inject(AlfrescoApiService);
 
-        const builder = new SearchQueryBuilderService(buildConfig({}), alfrescoApiService);
+        const builder = new SearchQueryBuilderServiceImpl(buildConfig({}), alfrescoApiService);
         builder.userQuery = 'nuka cola quantum';
         const queryBody = builder.buildQuery();
 
@@ -724,7 +724,7 @@ describe('SearchQueryBuilder', () => {
         };
         const alfrescoApiService = TestBed.inject(AlfrescoApiService);
 
-        const builder = new SearchQueryBuilderService(buildConfig(config), alfrescoApiService);
+        const builder = new SearchQueryBuilderServiceImpl(buildConfig(config), alfrescoApiService);
         builder.userQuery = 'nuka cola quantum';
         const queryBody = builder.buildQuery();
 
@@ -734,7 +734,7 @@ describe('SearchQueryBuilder', () => {
     it('should the query contain the pagination', () => {
         const alfrescoApiService = TestBed.inject(AlfrescoApiService);
 
-        const builder = new SearchQueryBuilderService(buildConfig({}), alfrescoApiService);
+        const builder = new SearchQueryBuilderServiceImpl(buildConfig({}), alfrescoApiService);
         builder.userQuery = 'nuka cola quantum';
         const mockPagination = {
             maxItems: 10,
@@ -749,7 +749,7 @@ describe('SearchQueryBuilder', () => {
     it('should the query contain the scope in case it is defined', () => {
         const alfrescoApiService = TestBed.inject(AlfrescoApiService);
 
-        const builder = new SearchQueryBuilderService(buildConfig({}), alfrescoApiService);
+        const builder = new SearchQueryBuilderServiceImpl(buildConfig({}), alfrescoApiService);
         const mockScope = { locations: 'mock-location' };
         builder.userQuery = 'nuka cola quantum';
         builder.setScope(mockScope);
@@ -761,7 +761,7 @@ describe('SearchQueryBuilder', () => {
     it('should return empty if array of search config not found', (done) => {
         const alfrescoApiService = TestBed.inject(AlfrescoApiService);
 
-        const builder = new SearchQueryBuilderService(buildConfig(null), alfrescoApiService);
+        const builder = new SearchQueryBuilderServiceImpl(buildConfig(null), alfrescoApiService);
         builder.searchForms.subscribe((forms) => {
             expect(forms).toEqual([]);
             done();
@@ -805,7 +805,7 @@ describe('SearchQueryBuilder', () => {
             ];
             const alfrescoApiService = TestBed.inject(AlfrescoApiService);
 
-            builder = new SearchQueryBuilderService(buildConfig(configs), alfrescoApiService);
+            builder = new SearchQueryBuilderServiceImpl(buildConfig(configs), alfrescoApiService);
         });
 
         it('should pick the default configuration from list', () => {

--- a/lib/content-services/src/lib/search/services/search-query-builder.service.ts
+++ b/lib/content-services/src/lib/search/services/search-query-builder.service.ts
@@ -16,22 +16,157 @@
  */
 
 import { Injectable } from '@angular/core';
+import { from, Observable } from 'rxjs';
 import { AlfrescoApiService, AppConfigService } from '@alfresco/adf-core';
+import {
+    QueryBody,
+    ResultSetPaging,
+    SearchApi
+} from '@alfresco/js-api';
 import { SearchConfiguration } from '../models/search-configuration.interface';
 import { BaseQueryBuilderService } from './base-query-builder.service';
 
-@Injectable()
-export class SearchQueryBuilderService extends BaseQueryBuilderService {
+@Injectable({
+    providedIn: 'root'
+})
+export abstract class SearchQueryBuilderService extends BaseQueryBuilderService {
+
+    constructor(protected appConfig: AppConfigService) {
+        super(appConfig);
+    }
 
     public isFilterServiceActive(): boolean {
         return false;
     }
 
-    constructor(appConfig: AppConfigService, alfrescoApiService: AlfrescoApiService) {
-        super(appConfig, alfrescoApiService);
-    }
-
     public loadConfiguration(): SearchConfiguration {
         return this.appConfig.get<SearchConfiguration>('search');
+    }
+
+    abstract set searchQuery(word);
+
+    // /*  Stream that emits the search configuration whenever the user change the search forms */
+    // configUpdated: Subject<SearchConfiguration>;
+
+    // /*  Stream that emits the query before search whenever user search  */
+    // updated: Subject<QueryBody>;
+
+    // /*  Stream that emits the results whenever user search  */
+    // executed: Subject<ResultSetPaging>;
+
+    // /*  Stream that emits the error whenever user search  */
+    // error: Subject<any>;
+
+    // /*  Stream that emits search forms  */
+    // searchForms = new ReplaySubject<SearchForm[]>(1);
+
+    // paging: { maxItems?: number; skipCount?: number };
+
+    // userQuery: string;
+
+    // categories: SearchCategory[] = [];
+    // queryFragments: { [id: string]: string } = {};
+
+    // /**
+    //  * Builds the current query and triggers the `updated` event.
+    //  */
+    // abstract update(): void;
+
+    // abstract resetToDefaults(): void;
+
+    // abstract execute(queryBody?: QueryBody);
+
+    // /**
+    //  * Gets the primary sorting definition.
+    //  * @returns The primary sorting definition
+    //  */
+    // abstract getPrimarySorting(): SearchSortingDefinition;
+
+    // /**
+    //  * Adds a filter query to the current query.
+    //  * @param query Query string to add
+    //  */
+    // abstract addFilterQuery(query: string): void;
+}
+
+@Injectable()
+export class SearchQueryBuilderServiceImpl extends SearchQueryBuilderService {
+
+    constructor(appConfig: AppConfigService, private alfrescoApiService: AlfrescoApiService) {
+        super(appConfig);
+    }
+
+    _searchApi: SearchApi;
+    get searchApi(): SearchApi {
+        this._searchApi = this._searchApi ?? new SearchApi(this.alfrescoApiService.getInstance());
+        return this._searchApi;
+    }
+
+    _doSearch(queryBody: QueryBody): Observable<ResultSetPaging> {
+        return from(this.searchApi.search(queryBody));
+    }
+
+    protected isOperator(input: string): boolean {
+        if (input) {
+            input = input.trim().toUpperCase();
+
+            const operators = ['AND', 'OR'];
+            return operators.includes(input);
+        }
+        return false;
+    }
+
+    protected formatFields(fields: string[], term: string): string {
+        let prefix = '';
+        let suffix = '*';
+
+        if (term.startsWith('=')) {
+            prefix = '=';
+            suffix = '';
+            term = term.substring(1);
+        }
+
+        return '(' + fields.map((field) => `${prefix}${field}:"${term}${suffix}"`).join(' OR ') + ')';
+    }
+
+    protected formatSearchQuery(userInput: string, fields = ['cm:name']) {
+        if (!userInput) {
+            return null;
+        }
+
+        if (/^http[s]?:\/\//.test(userInput)) {
+            return this.formatFields(fields, userInput);
+        }
+
+        userInput = userInput.trim();
+
+        if (userInput.includes(':') || userInput.includes('"')) {
+            return userInput;
+        }
+
+        const words = userInput.split(' ');
+
+        if (words.length > 1) {
+            const separator = words.some(this.isOperator) ? ' ' : ' AND ';
+
+            return words
+            .map((term) => {
+                if (this.isOperator(term)) {
+                return term;
+                }
+
+                return this.formatFields(fields, term);
+            })
+            .join(separator);
+        }
+
+        return this.formatFields(fields, userInput);
+    }
+
+    set searchQuery(word) {
+        const query = this.formatSearchQuery(word, this.config['aca:fields']);
+        if (query) {
+            this.userQuery = decodeURIComponent(query);
+        }
     }
 }

--- a/lib/content-services/src/lib/upload/components/file-uploading-list-row.component.ts
+++ b/lib/content-services/src/lib/upload/components/file-uploading-list-row.component.ts
@@ -51,7 +51,7 @@ export class FileUploadingListRowComponent {
     }
 
     get versionNumber(): string {
-        return this.file.data.entry.properties['cm:versionLabel'];
+        return this.file.data.entry?.properties['cm:versionLabel'];
     }
 
     get mimeType(): string {
@@ -67,8 +67,8 @@ export class FileUploadingListRowComponent {
             !!this.file.data &&
             this.file.options &&
             this.file.options.newVersion &&
-            this.file.data.entry.properties &&
-            this.file.data.entry.properties['cm:versionLabel']
+            this.file.data.entry?.properties &&
+            this.file.data.entry?.properties['cm:versionLabel']
         );
     }
 }

--- a/lib/content-services/src/lib/upload/components/upload-button.component.ts
+++ b/lib/content-services/src/lib/upload/components/upload-button.component.ts
@@ -17,7 +17,7 @@
 
 import {
     ContentService, EXTENDIBLE_COMPONENT, FileUtils,
-    LogService, NodeAllowableOperationSubject, TranslationService, UploadService, AllowableOperationsEnum
+    LogService, NodeAllowableOperationSubject, NodesApiService, TranslationService, UploadService, AllowableOperationsEnum
 } from '@alfresco/adf-core';
 import {
     Component, EventEmitter, forwardRef, Input,
@@ -69,6 +69,7 @@ export class UploadButtonComponent extends UploadBase implements OnInit, OnChang
 
     constructor(protected uploadService: UploadService,
                 private contentService: ContentService,
+                private nodesService: NodesApiService,
                 protected translationService: TranslationService,
                 protected logService: LogService,
                 protected ngZone: NgZone) {
@@ -134,8 +135,8 @@ export class UploadButtonComponent extends UploadBase implements OnInit, OnChang
                 include: ['allowableOperations']
             };
 
-            this.contentService.getNode(this.rootFolderId, opts).subscribe(
-                (res) => this.permissionValue.next(this.nodeHasPermission(res.entry, AllowableOperationsEnum.CREATE)),
+            this.nodesService.getNode(this.rootFolderId, opts).subscribe(
+                (res) => this.permissionValue.next(this.nodeHasPermission(res, AllowableOperationsEnum.CREATE)),
                 (error: { error: Error }) => {
                     if (error && error.error) {
                         this.error.emit({ error: error.error.message } as any);

--- a/lib/core/form/components/widgets/content/content.widget.ts
+++ b/lib/core/form/components/widgets/content/content.widget.ts
@@ -16,6 +16,7 @@
  */
 
 import { ContentService } from '../../../../services/content.service';
+import { DownloadService } from '../../../../services/download.service';
 import { LogService } from '../../../../services/log.service';
 import { Component, EventEmitter, Input, OnChanges, Output, SimpleChanges, ViewEncapsulation } from '@angular/core';
 import { Observable } from 'rxjs';
@@ -60,6 +61,7 @@ export class ContentWidgetComponent implements OnChanges {
     constructor(protected formService: FormService,
                 private logService: LogService,
                 private contentService: ContentService,
+                private downloadService: DownloadService,
                 private processContentService: ProcessContentService) {
     }
 
@@ -133,7 +135,7 @@ export class ContentWidgetComponent implements OnChanges {
      */
     download(content: ContentLinkModel): void {
         this.processContentService.getFileRawContent(content.id).subscribe(
-            (blob: Blob) => this.contentService.downloadBlob(blob, content.name),
+            (blob: Blob) => this.downloadService.downloadBlob(blob, content.name),
             (error) => {
                 this.error.emit(error);
             }

--- a/lib/core/services/discovery-api.service.ts
+++ b/lib/core/services/discovery-api.service.ts
@@ -19,9 +19,8 @@ import { Injectable } from '@angular/core';
 import { from, Observable, throwError, Subject } from 'rxjs';
 import { BpmProductVersionModel, EcmProductVersionModel } from '../models/product-version.model';
 import { AlfrescoApiService } from './alfresco-api.service';
-import { catchError, map, switchMap, filter, take } from 'rxjs/operators';
+import { catchError, map } from 'rxjs/operators';
 import { AboutApi, DiscoveryApi, SystemPropertiesApi, SystemPropertiesRepresentation } from '@alfresco/js-api';
-import { AuthenticationService } from './authentication.service';
 
 @Injectable({
     providedIn: 'root'
@@ -34,9 +33,9 @@ export class DiscoveryApiService {
     ecmProductInfo$ = new Subject<EcmProductVersionModel>();
 
     constructor(
-        private apiService: AlfrescoApiService,
-        private authenticationService: AuthenticationService) {
+        private apiService: AlfrescoApiService) {
 
+            /*
         this.authenticationService.onLogin
             .pipe(
                 filter(() => this.apiService.getInstance()?.isEcmLoggedIn()),
@@ -44,6 +43,7 @@ export class DiscoveryApiService {
                 switchMap(() => this.getEcmProductInfo())
             )
             .subscribe((info) => this.ecmProductInfo$.next(info));
+            */
     }
 
     /**

--- a/lib/core/services/ecm-user.service.ts
+++ b/lib/core/services/ecm-user.service.ts
@@ -17,7 +17,7 @@
 
 import { Injectable } from '@angular/core';
 import { Observable, from } from 'rxjs';
-import { map } from 'rxjs/operators';
+// import { map } from 'rxjs/operators';
 import { ContentService } from './content.service';
 import { AlfrescoApiService } from './alfresco-api.service';
 import { EcmUserModel } from '../models/ecm-user.model';
@@ -44,10 +44,9 @@ export class EcmUserService {
      * @returns User information
      */
     getUserInfo(userName: string): Observable<EcmUserModel> {
-        return from(this.peopleApi.getPerson(userName))
-            .pipe(
-                map((personEntry) => new EcmUserModel(personEntry.entry))
-            );
+        return from([new EcmUserModel({
+            id: userName
+        })]);
     }
 
     /**

--- a/lib/core/services/identity-user.service.ts
+++ b/lib/core/services/identity-user.service.ts
@@ -49,10 +49,10 @@ export class IdentityUserService implements IdentityUserServiceInterface {
      * @returns The user's details
      */
     getCurrentUserInfo(): IdentityUserModel {
-        const familyName = this.jwtHelperService.getValueFromLocalAccessToken<string>(JwtHelperService.FAMILY_NAME);
-        const givenName = this.jwtHelperService.getValueFromLocalAccessToken<string>(JwtHelperService.GIVEN_NAME);
-        const email = this.jwtHelperService.getValueFromLocalAccessToken<string>(JwtHelperService.USER_EMAIL);
-        const username = this.jwtHelperService.getValueFromLocalAccessToken<string>(JwtHelperService.USER_PREFERRED_USERNAME);
+        const familyName = this.jwtHelperService.getValueFromLocalIdToken<string>(JwtHelperService.FAMILY_NAME);
+        const givenName = this.jwtHelperService.getValueFromLocalIdToken<string>(JwtHelperService.GIVEN_NAME);
+        const email = this.jwtHelperService.getValueFromLocalIdToken<string>(JwtHelperService.USER_EMAIL);
+        const username = this.jwtHelperService.getValueFromLocalIdToken<string>(JwtHelperService.USER_PREFERRED_USERNAME);
         return { firstName: givenName, lastName: familyName, email: email, username: username };
     }
 

--- a/lib/core/services/jwt-helper.service.ts
+++ b/lib/core/services/jwt-helper.service.ts
@@ -28,6 +28,7 @@ export class JwtHelperService {
     static GIVEN_NAME = 'given_name';
     static USER_EMAIL = 'email';
     static USER_ACCESS_TOKEN = 'access_token';
+    static USER_ID_TOKEN = 'id_token';
     static REALM_ACCESS = 'realm_access';
     static RESOURCE_ACCESS = 'resource_access';
     static USER_PREFERRED_USERNAME = 'preferred_username';
@@ -91,6 +92,23 @@ export class JwtHelperService {
      */
     getAccessToken(): string {
         return this.storageService.getItem(JwtHelperService.USER_ACCESS_TOKEN);
+    }
+
+    /**
+     * Gets a named value from the user id token.
+     * @param key Key name of the field to retrieve
+     * @returns Value from the token
+     */
+     getValueFromLocalIdToken<T>(key: string): T {
+        return this.getValueFromToken(this.getIdToken(), key);
+    }
+
+    /**
+     * Gets id token
+     * @returns id token
+     */
+     getIdToken(): string {
+        return this.storageService.getItem(JwtHelperService.USER_ID_TOKEN);
     }
 
     /**

--- a/lib/core/services/upload.service.ts
+++ b/lib/core/services/upload.service.ts
@@ -33,21 +33,20 @@ import { NodesApi, UploadApi, VersionsApi } from '@alfresco/js-api';
 
 const MIN_CANCELLABLE_FILE_SIZE = 1000000;
 const MAX_CANCELLABLE_FILE_PERCENTAGE = 50;
-
 @Injectable({
     providedIn: 'root'
 })
 export class UploadService {
-    private cache: { [key: string]: any } = {};
-    private totalComplete: number = 0;
-    private totalAborted: number = 0;
-    private totalError: number = 0;
-    private excludedFileList: string[] = [];
-    private excludedFoldersList: string[] = [];
-    private matchingOptions: any = null;
-    private folderMatchingOptions: any = null;
-    private abortedFile: string;
-    private isThumbnailGenerationEnabled: boolean;
+    protected cache: { [key: string]: any } = {};
+    protected totalComplete: number = 0;
+    protected totalAborted: number = 0;
+    protected totalError: number = 0;
+    protected excludedFileList: string[] = [];
+    protected excludedFoldersList: string[] = [];
+    protected matchingOptions: any = null;
+    protected folderMatchingOptions: any = null;
+    protected abortedFile: string;
+    protected isThumbnailGenerationEnabled: boolean;
 
     activeTask: Promise<any> = null;
     queue: FileModel[] = [];
@@ -64,27 +63,27 @@ export class UploadService {
     fileDeleted: Subject<string> = new Subject<string>();
 
     _uploadApi: UploadApi;
-    get uploadApi(): UploadApi {
+    private get uploadApi(): UploadApi {
         this._uploadApi = this._uploadApi ?? new UploadApi(this.apiService.getInstance());
         return this._uploadApi;
     }
 
     _nodesApi: NodesApi;
-    get nodesApi(): NodesApi {
+    private get nodesApi(): NodesApi {
         this._nodesApi = this._nodesApi ?? new NodesApi(this.apiService.getInstance());
         return this._nodesApi;
     }
 
     _versionsApi: VersionsApi;
-    get versionsApi(): VersionsApi {
+    private get versionsApi(): VersionsApi {
         this._versionsApi = this._versionsApi ?? new VersionsApi(this.apiService.getInstance());
         return this._versionsApi;
     }
 
     constructor(
         protected apiService: AlfrescoApiService,
-        private appConfigService: AppConfigService,
-        private discoveryApiService: DiscoveryApiService) {
+        protected appConfigService: AppConfigService,
+        protected discoveryApiService: DiscoveryApiService) {
 
         this.discoveryApiService.ecmProductInfo$.pipe(filter(info => !!info))
             .subscribe(({ status }) => {
@@ -321,7 +320,7 @@ export class UploadService {
         return promise;
     }
 
-    private onUploadStarting(file: FileModel): void {
+    protected onUploadStarting(file: FileModel): void {
         if (file) {
             file.status = FileUploadStatus.Starting;
             const event = new FileUploadEvent(file, FileUploadStatus.Starting);
@@ -330,7 +329,7 @@ export class UploadService {
         }
     }
 
-    private onUploadProgress(
+    protected onUploadProgress(
         file: FileModel,
         progress: FileUploadProgress
     ): void {
@@ -344,7 +343,7 @@ export class UploadService {
         }
     }
 
-    private onUploadError(file: FileModel, error: any): void {
+    protected onUploadError(file: FileModel, error: any): void {
         if (file) {
             file.errorCode = (error || {}).status;
             file.status = FileUploadStatus.Error;
@@ -365,7 +364,7 @@ export class UploadService {
         }
     }
 
-    private onUploadComplete(file: FileModel, data: any): void {
+    protected onUploadComplete(file: FileModel, data: any): void {
         if (file) {
             file.status = FileUploadStatus.Complete;
             file.data = data;
@@ -386,7 +385,7 @@ export class UploadService {
         }
     }
 
-    private onUploadAborted(file: FileModel): void {
+    protected onUploadAborted(file: FileModel): void {
         if (file) {
             file.status = FileUploadStatus.Aborted;
             this.totalAborted++;
@@ -397,7 +396,7 @@ export class UploadService {
         }
     }
 
-    private onUploadCancelled(file: FileModel): void {
+    protected onUploadCancelled(file: FileModel): void {
         if (file) {
             file.status = FileUploadStatus.Cancelled;
 
@@ -407,7 +406,7 @@ export class UploadService {
         }
     }
 
-    private onUploadDeleted(file: FileModel): void {
+    protected onUploadDeleted(file: FileModel): void {
         if (file) {
             file.status = FileUploadStatus.Deleted;
             this.totalComplete--;

--- a/lib/core/viewer/components/img-viewer.component.html
+++ b/lib/core/viewer/components/img-viewer.component.html
@@ -1,5 +1,5 @@
 <div id="adf-image-container" (keydown)="onKeyDown($event)" class="adf-image-container" tabindex="0" role="img" [attr.aria-label]="nameFile" data-automation-id="adf-image-container">
-    <img #image id="viewer-image" [src]="urlFile" [alt]="nameFile" (error)="onImageError()" />
+    <img #image id="viewer-image" [src]="urlFile" [alt]="nameFile" (error)="onImageError()" crossOrigin="use-credentials"/>
 </div>
 
 <div class="adf-image-viewer__toolbar" *ngIf="showToolbar">

--- a/lib/core/viewer/components/img-viewer.component.ts
+++ b/lib/core/viewer/components/img-viewer.component.ts
@@ -92,7 +92,7 @@ export class ImgViewerComponent implements AfterViewInit, OnChanges {
             zoomOnWheel: false,
             toggleDragModeOnDblclick: false,
             viewMode: 1,
-            checkCrossOrigin: false,
+            checkCrossOrigin: true,
             ready: () => {
                 this.updateCanvasContainer();
             }

--- a/lib/process-services-cloud/src/lib/form/services/process-cloud-content.service.ts
+++ b/lib/process-services-cloud/src/lib/form/services/process-cloud-content.service.ts
@@ -74,7 +74,7 @@ export class ProcessCloudContentService {
     }
 
     downloadNodeContent(blob: Blob, fileName: string): void {
-        this.contentService.downloadBlob(blob, fileName);
+        this.downloadService.downloadBlob(blob, fileName);
     }
 
     async downloadFile(nodeId: string) {


### PR DESCRIPTION
Because sometimes it's easier to discuss over code this is a very hacky go at making ADF able to integrate with different CS providers.

This work was done a while ago and the plan was for it to be picked up by the ngWeb team but since then both Zack and Jason have left 🤷‍♂️ 

At the time I had identified as work to be done:

**HxP IdP integration**
- different OAuth endpoints, PR already merged upstream https://github.com/Alfresco/alfresco-js-api/pull/1257)
- claims in ID token, not access token (got some wip and should be able to open a PR still keeping compat)
no ECM SSO ticket, HxPR takes the JWT token (guess we could put this behind a conf flag)

**HxCS integration**
- need to introduce proper service interfaces, with existing implementations as default providers. Got some wip with the NodesApiService. Doing it at the AngularJS service level seemed cleaner than at the JS client level since we can better control the granularity of the requests (eg with GQL we may fetch more data at once) and also because the services are reactive whereas the JS client is not, this makes it possible to leverage something like apollo-angular.
- need to provide HxPR (REST or GQL) implementation for the services. Got some super basic wip with the NodesApiService and apollo-angular
- need to ensure consistent usage of the service interfaces across the code base. Direct instantiation of the API services instead of relying on injection makes it impossible to switch implementation. Got some wip updating the DocumentListService to rely on the NodesApiService which means the DocumentListComponent can work with both Alfresco and HxPR.
